### PR TITLE
Rename project to os_detect.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://api.travis-ci.org/dart-lang/os_id.svg?branch=master)](https://travis-ci.org/github/dart-lang/os_id)
+[![Build Status](https://api.travis-ci.org/dart-lang/os_detect.svg?branch=master)](https://travis-ci.org/github/dart-lang/os_detect)
 
 Platform independent access to information about the current operating system.
 
@@ -14,7 +14,7 @@ based on the `operatingSystem` string.
 To use this package instead of `dart:io`, replace
 the import of `dart:io` with:
 ```dart
-import "package:os_id/os_id.dart" as Platform;
+import "package:os_detect/os_detect.dart" as Platform;
 ```
 That should keep the code working if the only functionality used from `dart:io`
 is operating system detection.
@@ -30,8 +30,8 @@ so that `const String.fromEnvironment` can access them.
 
 It's possible to override the current operating system string,
 as exposed by `operatingSystem` and `operatingSystemVersion`
-in `package:os_id/os_id.dart`.
-To do so, import the `package:os_id/override.dart` library
+in `package:os_detect/os_detect.dart`.
+To do so, import the `package:os_detect/override.dart` library
 and use the `overrideOperatingSystem` function to run code in a zone
 where the operating system and version values are set
 to whatever values are desired.

--- a/lib/os_detect.dart
+++ b/lib/os_detect.dart
@@ -3,20 +3,19 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Information about the current operating system.
-library pkg.os_id;
+library pkg.os_detect;
 
 import 'override.dart';
 
 /// Identification of the current operating system or platform.
 ///
 /// Specific known operating systems are reported by a unique string.
-String get operatingSystem => OperatingSystemID.current.operatingSystem;
+String get operatingSystem => OperatingSystem.current.id;
 
 /// Representation of the version of the current operating system or platform.
 ///
 /// May be empty if no version is known or available.
-String get operatingSystemVersion =>
-    OperatingSystemID.current.operatingSystemVersion;
+String get operatingSystemVersion => OperatingSystem.current.version;
 
 /// Whether the current operating system is a version of
 /// [Linux](https://en.wikipedia.org/wiki/Linux).
@@ -26,37 +25,37 @@ String get operatingSystemVersion =>
 /// This value is `false` if the operating system is a specialized
 /// version of Linux that identifies itself by a different name,
 /// for example Android (see [isAndroid]).
-bool get isLinux => OperatingSystemID.current.isLinux;
+bool get isLinux => OperatingSystem.current.isLinux;
 
 /// Whether the current operating system is a version of
 /// [macOS](https://en.wikipedia.org/wiki/MacOS).
 ///
 /// Identified by [operatingSystem] being the string `macos`.
-bool get isMacOS => OperatingSystemID.current.isMacOS;
+bool get isMacOS => OperatingSystem.current.isMacOS;
 
 /// Whether the current operating system is a version of
 /// [Microsoft Windows](https://en.wikipedia.org/wiki/Microsoft_Windows).
 ///
 /// Identified by [operatingSystem] being the string `windows`.
-bool get isWindows => OperatingSystemID.current.isWindows;
+bool get isWindows => OperatingSystem.current.isWindows;
 
 /// Whether the current operating system is a version of
 /// [Android](https://en.wikipedia.org/wiki/Android_%28operating_system%29).
 ///
 /// Identified by [operatingSystem] being the string `android`.
-bool get isAndroid => OperatingSystemID.current.isAndroid;
+bool get isAndroid => OperatingSystem.current.isAndroid;
 
 /// Whether the current operating system is a version of
 /// [iOS](https://en.wikipedia.org/wiki/IOS).
 ///
 /// Identified by [operatingSystem] being the string `ios`.
-bool get isIOS => OperatingSystemID.current.isIOS;
+bool get isIOS => OperatingSystem.current.isIOS;
 
 /// Whether the current operating system is a version of
 /// [Fuchsia](https://en.wikipedia.org/wiki/Google_Fuchsia).
 ///
 /// Identified by [operatingSystem] being the string `fuchsia`.
-bool get isFuchsia => OperatingSystemID.current.isFuchsia;
+bool get isFuchsia => OperatingSystem.current.isFuchsia;
 
 /// Whether running in a web browser.
 ///
@@ -64,4 +63,4 @@ bool get isFuchsia => OperatingSystemID.current.isFuchsia;
 ///
 /// If so, the [operatingSystemVersion] is the string made available
 /// through `window.navigator.appVersion`.
-bool get isBrowser => OperatingSystemID.current.isBrowser;
+bool get isBrowser => OperatingSystem.current.isBrowser;

--- a/lib/override.dart
+++ b/lib/override.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Functionality to override information about the current platform.
-library pkg.os_id.override;
+library pkg.os_detect.override;
 
 import "dart:async" show Zone, runZoned;
 
@@ -12,88 +12,88 @@ import 'src/osid_unknown.dart'
     if (dart.library.html) "src/osid_html.dart";
 
 /// The name and version of an operating system.
-class OperatingSystemID {
+class OperatingSystem {
   /// The current operating system ID.
   ///
   /// Defaults to what information is available
   /// from known platform specific libraries,
   /// but can be overridden using functionality from the
   /// `osid_override.dart` library.
-  static OperatingSystemID get current => Zone.current[#_osid] ?? platformOSID;
+  static OperatingSystem get current => Zone.current[#_os] ?? platformOS;
 
   /// A string representing the operating system or platform.
-  final String operatingSystem;
+  final String id;
 
   /// A string representing the version of the operating system or platform.
   ///
   /// May be empty if no version is known or available.
-  final String operatingSystemVersion;
+  final String version;
 
   /// Creates an operating system ID with the provided values.
-  const OperatingSystemID(this.operatingSystem, this.operatingSystemVersion);
+  const OperatingSystem(this.id, this.version);
 }
 
-/// Convenience operations on [OperatingSystemID].
+/// Convenience operations on [OperatingSystem].
 ///
-/// Implemented as extensions to allow users to *implement* [OperatingSystemID]
+/// Implemented as extensions to allow users to *implement* [OperatingSystem]
 /// without having to implement all of these getters.
-extension OperatingSystemIDGetters on OperatingSystemID {
+extension OperatingSystemGetters on OperatingSystem {
   /// Whether the operating system is a version of
   /// [Linux](https://en.wikipedia.org/wiki/Linux).
   ///
-  /// Identified by [operatingSystem] being the string `linux`.
+  /// Identified by [id] being the string `linux`.
   ///
   /// This value is `false` if the operating system is a specialized
   /// version of Linux that identifies itself by a different name,
   /// for example Android (see [isAndroid]).
-  bool get isLinux => ("linux" == operatingSystem);
+  bool get isLinux => ("linux" == id);
 
   /// Whether the operating system is a version of
   /// [macOS](https://en.wikipedia.org/wiki/MacOS).
   ///
-  /// Identified by [operatingSystem] being the string `macos`.
-  bool get isMacOS => ("macos" == operatingSystem);
+  /// Identified by [id] being the string `macos`.
+  bool get isMacOS => ("macos" == id);
 
   /// Whether the operating system is a version of
   /// [Microsoft Windows](https://en.wikipedia.org/wiki/Microsoft_Windows).
   ///
-  /// Identified by [operatingSystem] being the string `windows`.
-  bool get isWindows => ("windows" == operatingSystem);
+  /// Identified by [id] being the string `windows`.
+  bool get isWindows => ("windows" == id);
 
   /// Whether the operating system is a version of
   /// [Android](https://en.wikipedia.org/wiki/Android_%28operating_system%29).
   ///
-  /// Identified by [operatingSystem] being the string `android`.
-  bool get isAndroid => ("android" == operatingSystem);
+  /// Identified by [id] being the string `android`.
+  bool get isAndroid => ("android" == id);
 
   /// Whether the operating system is a version of
   /// [iOS](https://en.wikipedia.org/wiki/IOS).
   ///
-  /// Identified by [operatingSystem] being the string `ios`.
-  bool get isIOS => ("ios" == operatingSystem);
+  /// Identified by [id] being the string `ios`.
+  bool get isIOS => ("ios" == id);
 
   /// Whether the operating system is a version of
   /// [Fuchsia](https://en.wikipedia.org/wiki/Google_Fuchsia).
   ///
-  /// Identified by [operatingSystem] being the string `fuchsia`.
-  bool get isFuchsia => ("fuchsia" == operatingSystem);
+  /// Identified by [id] being the string `fuchsia`.
+  bool get isFuchsia => ("fuchsia" == id);
 
   /// Whether running in a web browser.
   ///
-  /// Identified by [operatingSystem] being the string `browser`.
+  /// Identified by [id] being the string `browser`.
   ///
-  /// If so, the [operatingSystemVersion] is the string made available
+  /// If so, the [version] is the string made available
   /// through `window.navigator.appVersion`.
-  bool get isBrowser => ("browser" == operatingSystem);
+  bool get isBrowser => ("browser" == id);
 }
 
 /// Run [body] in a zone with platform overrides.
 ///
-/// Overrides [OperatingSystemID.current] with the supplied [osId]
+/// Overrides [OperatingSystem.current] with the supplied [osId]
 /// value while running in a new zone, and then runs [body] in that zone.
 ///
-/// This override affects the `operatingSystem` and `operatingSystemVersion`
+/// This override affects the `operatingSystem` and `version`
 /// exported by `package:osid/osid.dart`.
-R overrideOperatingSystem<R>(OperatingSystemID osId, R body()) {
-  return runZoned(body, zoneValues: {#_osid: osId});
+R overrideOperatingSystem<R>(OperatingSystem operatingSystem, R body()) {
+  return runZoned(body, zoneValues: {#_os: operatingSystem});
 }

--- a/lib/src/osid_html.dart
+++ b/lib/src/osid_html.dart
@@ -9,4 +9,4 @@ import '../override.dart';
 const String _os = "browser";
 String get _osVersion => window.navigator.appVersion;
 
-final OperatingSystemID platformOSID = OperatingSystemID(_os, _osVersion);
+final OperatingSystem platformOS = OperatingSystem(_os, _osVersion);

--- a/lib/src/osid_io.dart
+++ b/lib/src/osid_io.dart
@@ -9,4 +9,4 @@ import '../override.dart';
 String get _os => Platform.operatingSystem;
 String get _osVersion => Platform.operatingSystemVersion;
 
-final OperatingSystemID platformOSID = OperatingSystemID(_os, _osVersion);
+final OperatingSystem platformOS = OperatingSystem(_os, _osVersion);

--- a/lib/src/osid_unknown.dart
+++ b/lib/src/osid_unknown.dart
@@ -8,4 +8,4 @@ const String _os =
     String.fromEnvironment("dart.os.name", defaultValue: "unknown");
 const String _osVersion = String.fromEnvironment("dart.os.version");
 
-const OperatingSystemID platformOSID = OperatingSystemID(_os, _osVersion);
+const OperatingSystem platformOS = OperatingSystem(_os, _osVersion);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-name: os_id
+name: os_detect
 version: 1.0.0
 environment:
   sdk: ">=2.8.0 <3.0.0"

--- a/test/osid_test.dart
+++ b/test/osid_test.dart
@@ -4,8 +4,8 @@
 
 import "dart:async";
 
-import "package:os_id/os_id.dart";
-import 'package:os_id/override.dart';
+import "package:os_detect/os_detect.dart";
+import 'package:os_detect/override.dart';
 
 import "package:test/test.dart";
 
@@ -26,31 +26,31 @@ void main() {
   test("Override", () {
     const overrideName = "argle-bargle";
     const overrideVersion = "glop-glyf";
-    const overrideID = OperatingSystemID(overrideName, overrideVersion);
+    const overrideOS = OperatingSystem(overrideName, overrideVersion);
     Zone /*?*/ overrideZone;
 
     var originalName = operatingSystem;
     var originalVersion = operatingSystemVersion;
-    var originalID = OperatingSystemID.current;
+    var originalID = OperatingSystem.current;
     var originalZone = Zone.current;
     expect(originalName, isNot(overrideName));
     expect(originalVersion, isNot(overrideVersion));
 
     // Override OS ID.
-    overrideOperatingSystem(overrideID, () {
+    overrideOperatingSystem(overrideOS, () {
       overrideZone = Zone.current;
       expect(operatingSystem, overrideName);
       expect(operatingSystemVersion, overrideVersion);
-      expect(OperatingSystemID.current, same(overrideID));
+      expect(OperatingSystem.current, same(overrideOS));
       // Nested override.
       overrideOperatingSystem(originalID, () {
         expect(operatingSystem, originalName);
         expect(operatingSystemVersion, originalVersion);
-        expect(OperatingSystemID.current, same(originalID));
+        expect(OperatingSystem.current, same(originalID));
       });
       expect(operatingSystem, overrideName);
       expect(operatingSystemVersion, overrideVersion);
-      expect(OperatingSystemID.current, same(overrideID));
+      expect(OperatingSystem.current, same(overrideOS));
       // Captured parent zone does not have override.
       originalZone.run(() {
         expect(operatingSystem, originalName);
@@ -58,7 +58,7 @@ void main() {
       });
       expect(operatingSystem, overrideName);
       expect(operatingSystemVersion, overrideVersion);
-      expect(OperatingSystemID.current, same(overrideID));
+      expect(OperatingSystem.current, same(overrideOS));
     });
 
     expect(operatingSystem, originalName);
@@ -68,7 +68,7 @@ void main() {
     overrideZone /*!*/ .run(() {
       expect(operatingSystem, overrideName);
       expect(operatingSystemVersion, overrideVersion);
-      expect(OperatingSystemID.current, same(overrideID));
+      expect(OperatingSystem.current, same(overrideOS));
     });
   });
 }


### PR DESCRIPTION
Also rename some classes and members in `override.dart` to
not say `OperatingSystemID` and not repeat "operating system"
unnecessarily.