### PR TITLE
Migrate to null safety

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: dart
 dart:
- - dev
+- dev
 # Disabling the stable build until 2.12 stable with null safety is available.
 # TODO: Enable stable testing in CI once 2.12 stable is ready.
 # - stable
 # Only building master means that we don't run two builds for each pull request.
 dart_task:
- - test: --platform vm,chrome
- - dartanalyzer
- - dartfmt
+- test: --platform vm,chrome
+- dartanalyzer
+- dartfmt
 branches:
   only: [master]
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: dart
 dart:
-- dev
-- stable
+ - dev
+# Disabling the stable build until 2.12 stable with null safety is available.
+# TODO: Enable stable testing in CI once 2.12 stable is ready.
+# - stable
 # Only building master means that we don't run two builds for each pull request.
 dart_task:
-- test: --platform vm,chrome
-- dartanalyzer
-- dartfmt
+ - test: --platform vm,chrome
+ - dartanalyzer
+ - dartfmt
 branches:
   only: [master]
 cache:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,9 +1,9 @@
 name: os_detect
-version: 1.0.0
+version: 1.1.0-nullsafety.0
 description: Platform independent OS detection.
 homepage: https://github.com/dart-lang/os_detect
 environment:
-  sdk: ">=2.8.0 <3.0.0"
+  sdk: '>=2.12.0-0 <3.0.0'
 dev_dependencies:
-  pedantic: ^1.9.0
-  test: ^1.15.0
+  pedantic: ^1.10.0-nullsafety
+  test: ^1.16.0-nullsafety

--- a/test/osid_test.dart
+++ b/test/osid_test.dart
@@ -6,7 +6,6 @@ import "dart:async";
 
 import "package:os_detect/os_detect.dart";
 import 'package:os_detect/override.dart';
-
 import "package:test/test.dart";
 
 void main() {
@@ -27,7 +26,7 @@ void main() {
     const overrideName = "argle-bargle";
     const overrideVersion = "glop-glyf";
     const overrideOS = OperatingSystem(overrideName, overrideVersion);
-    Zone /*?*/ overrideZone;
+    Zone? overrideZone;
 
     var originalName = operatingSystem;
     var originalVersion = operatingSystemVersion;
@@ -65,7 +64,7 @@ void main() {
     expect(operatingSystemVersion, originalVersion);
 
     // A captured override zone retains the override.
-    overrideZone /*!*/ .run(() {
+    overrideZone!.run(() {
       expect(operatingSystem, overrideName);
       expect(operatingSystemVersion, overrideVersion);
       expect(OperatingSystem.current, same(overrideOS));


### PR DESCRIPTION
Migrate this package to null safety.

There are no API changes at all, so I went with a minor version bump. Is that OK?