### PR TITLE
Use a major version bump for null safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-# Changelog
+## 2.0.0-nullsafety.0
+
+- Migrate to null safety.
 
 ## 1.0.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: os_detect
-version: 1.1.0-nullsafety.0
+version: 2.0.0-nullsafety.0
 description: Platform independent OS detection.
 homepage: https://github.com/dart-lang/os_detect
 environment:


### PR DESCRIPTION
Even though this package has very little usage follow the migration
guide including a breaking change version bump.