### PR TITLE
Improve tree-shaking:

### DIFF
--- a/lib/os_detect.dart
+++ b/lib/os_detect.dart
@@ -35,6 +35,7 @@ String get operatingSystemVersion => OperatingSystem.current.version;
 /// for example Android (see [isAndroid]),
 /// or if the code is running inside a browser (see [isBrowser]).
 @pragma('vm:prefer-inline')
+@pragma('dart2js:prefer-inline')
 bool get isLinux => OperatingSystem.current.isLinux;
 
 /// Whether the current operating system is a version of
@@ -45,6 +46,7 @@ bool get isLinux => OperatingSystem.current.isLinux;
 /// The value is `false` if the code is running inside a browser,
 /// even if that browser is running on MacOS (see [isBrowser]).
 @pragma('vm:prefer-inline')
+@pragma('dart2js:prefer-inline')
 bool get isMacOS => OperatingSystem.current.isMacOS;
 
 /// Whether the current operating system is a version of
@@ -55,6 +57,7 @@ bool get isMacOS => OperatingSystem.current.isMacOS;
 /// The value is `false` if the code is running inside a browser,
 /// even if that browser is running on Windows (see [isBrowser]).
 @pragma('vm:prefer-inline')
+@pragma('dart2js:prefer-inline')
 bool get isWindows => OperatingSystem.current.isWindows;
 
 /// Whether the current operating system is a version of
@@ -65,6 +68,7 @@ bool get isWindows => OperatingSystem.current.isWindows;
 /// The value is `false` if the code is running inside a browser,
 /// even if that browser is running on Android (see [isBrowser]).
 @pragma('vm:prefer-inline')
+@pragma('dart2js:prefer-inline')
 bool get isAndroid => OperatingSystem.current.isAndroid;
 
 /// Whether the current operating system is a version of
@@ -75,6 +79,7 @@ bool get isAndroid => OperatingSystem.current.isAndroid;
 /// The value is `false` if the code is running inside a browser,
 /// even if that browser is running on iOS (see [isBrowser]).
 @pragma('vm:prefer-inline')
+@pragma('dart2js:prefer-inline')
 bool get isIOS => OperatingSystem.current.isIOS;
 
 /// Whether the current operating system is a version of
@@ -85,6 +90,7 @@ bool get isIOS => OperatingSystem.current.isIOS;
 /// The value is `false` if the code is running inside a browser,
 /// even if that browser is running on Fuchsia (see [isBrowser]).
 @pragma('vm:prefer-inline')
+@pragma('dart2js:prefer-inline')
 bool get isFuchsia => OperatingSystem.current.isFuchsia;
 
 /// Whether running in a web browser.
@@ -101,4 +107,5 @@ bool get isFuchsia => OperatingSystem.current.isFuchsia;
 /// but browsers are able to lie in the app-version/user-agent
 /// string.
 @pragma('vm:prefer-inline')
+@pragma('dart2js:prefer-inline')
 bool get isBrowser => OperatingSystem.current.isBrowser;

--- a/lib/src/os_override.dart
+++ b/lib/src/os_override.dart
@@ -63,7 +63,8 @@ final class OperatingSystem {
   /// from known platform specific libraries,
   /// but can be overridden using functionality from the
   /// `osid_override.dart` library.
-  @pragma('vm:try-inline')
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
   static OperatingSystem get current =>
       Zone.current[#_os] as OperatingSystem? ?? platformOS;
 
@@ -73,10 +74,12 @@ final class OperatingSystem {
   // Operating system ID object.
   final RecognizedOS _osId;
 
+  final String Function() _computeVersion;
+
   /// A string representing the version of the operating system or platform.
   ///
   /// May be empty if no version is known or available.
-  final String version;
+  String get version => _computeVersion();
 
   /// Creates a new operating system object for testing.
   ///
@@ -91,7 +94,8 @@ final class OperatingSystem {
   // That can avoid retaining *all* the subclasses of `OS`.
   @visibleForTesting
   @pragma('vm:prefer-inline')
-  OperatingSystem(String id, String version)
+  @pragma('dart2js:prefer-inline')
+  OperatingSystem(String id, String Function() computeVersion)
       : this._(
             id == linuxId
                 ? const LinuxOS()
@@ -108,10 +112,10 @@ final class OperatingSystem {
                                     : id == browserId
                                         ? const BrowserOS()
                                         : UnknownOS(id),
-            version);
+            computeVersion);
 
   /// Used by platforms which know the ID object.
-  const OperatingSystem._(this._osId, this.version);
+  const OperatingSystem._(this._osId, this._computeVersion);
 
   /// Whether the operating system is a version of
   /// [Linux](https://en.wikipedia.org/wiki/Linux).
@@ -176,5 +180,5 @@ R overrideOperatingSystem<R>(
 // Exposes the `OperatingSystem._` constructor to the conditionally imported
 // libraries. Not exported by `../override.dart'.
 final class OperatingSystemInternal extends OperatingSystem {
-  const OperatingSystemInternal(super.id, super.version) : super._();
+  const OperatingSystemInternal(super.id, super.computeVersion) : super._();
 }

--- a/lib/src/os_override.dart
+++ b/lib/src/os_override.dart
@@ -95,7 +95,7 @@ final class OperatingSystem {
   @visibleForTesting
   @pragma('vm:prefer-inline')
   @pragma('dart2js:prefer-inline')
-  OperatingSystem(String id, String Function() computeVersion)
+  OperatingSystem(String id, String computeVersion)
       : this._(
             id == linuxId
                 ? const LinuxOS()
@@ -112,7 +112,7 @@ final class OperatingSystem {
                                     : id == browserId
                                         ? const BrowserOS()
                                         : UnknownOS(id),
-            computeVersion);
+            () => computeVersion);
 
   /// Used by platforms which know the ID object.
   const OperatingSystem._(this._osId, this._computeVersion);

--- a/lib/src/osid_html.dart
+++ b/lib/src/osid_html.dart
@@ -7,7 +7,7 @@ import 'dart:html';
 import 'os_kind.dart' show BrowserOS;
 import 'os_override.dart';
 
-String get _osVersion => window.navigator.appVersion;
+String _osVersion() => window.navigator.appVersion;
 
-final OperatingSystem platformOS =
-    OperatingSystemInternal(const BrowserOS(), _osVersion);
+const OperatingSystem platformOS =
+    OperatingSystemInternal(BrowserOS(), _osVersion);

--- a/lib/src/osid_io.dart
+++ b/lib/src/osid_io.dart
@@ -28,6 +28,8 @@ final RecognizedOS? _osType = Platform.operatingSystem == RecognizedOS.linuxId
                             ? const BrowserOS()
                             : null;
 
+String _osVersion() => Platform.operatingSystemVersion;
+
+@pragma('vm:platform-const')
 final OperatingSystem platformOS = OperatingSystemInternal(
-    _osType ?? UnknownOS(Platform.operatingSystem),
-    Platform.operatingSystemVersion);
+    _osType ?? UnknownOS(Platform.operatingSystem), _osVersion);

--- a/lib/src/osid_unknown.dart
+++ b/lib/src/osid_unknown.dart
@@ -8,7 +8,7 @@ import 'os_override.dart';
 @pragma('vm:platform-const')
 const String _os =
     String.fromEnvironment('dart.os.name', defaultValue: 'unknown');
-const String _osVersion = String.fromEnvironment('dart.os.version');
+String _osVersion() => const String.fromEnvironment('dart.os.version');
 
 const OperatingSystem platformOS = OperatingSystemInternal(
     _os == RecognizedOS.linuxId


### PR DESCRIPTION
* Use `dart2js:prefer-inline` everywhere where we use `vm:prefer-inline`.
* Make `platformOS` const/platform-const by wrapping version into a thunk. This means you don't have to lazy initialize the final field.
* Allow full constant folding of `OperatingSystem.current` if `overrideOperatingSystem` is never called in the program by going through an indirection. Without this indirection a bunch of goo stays behind after each invocation of `OperatingSystem.current` in the program 


